### PR TITLE
Update configuration to work with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-project(uoe-inf-thesis-latex NONE)
+project(uoe-inf-thesis-cls-latex NONE)
 
 #
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+# cmake file
+
+cmake_minimum_required(VERSION 2.8)
+
+project(uoe-inf-thesis-latex NONE)
+
+#
+
+add_subdirectory(src)
+

--- a/README.md
+++ b/README.md
@@ -44,5 +44,9 @@ and will also invoke `texhash` in order to update the search paths.
 To match the `make` based installation, `texhash` must be invoked manually, but it allows for greater flexibility on the
 selection of the target directory.
 
+Moreover, the `cmake` file `uoe-infthesis-latex-cls.cmake` allows the integration of this repository as a submodule, 
+allowing the creation of targets with the relevant files as shown in this project's `CMakeLists.txt` file. The handling
+of the paths for LaTeX will still need to be handled separately.
+
 
 [eushield.sty]: http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty

--- a/README.md
+++ b/README.md
@@ -21,16 +21,28 @@ You can obtain a copy of it via [Informatics DReaM](http://dream.inf.ed.ac.uk/pr
 
 ## Local installation
 
-To install the thesis class file:
+## Usimg `make`
+
+To install the thesis class file (in the `src` dir):
 
 `make install`
 
-To install the crest and logos:
+To install the crest and logos (in the `src` dir):
 
 `make install-eushield`
 
 Both above commands will place all the relevant files under a `.texmf` directory in the current user's `HOME` directory
 and will also invoke `texhash` in order to update the search paths.
+
+## Using `cmake`
+
+- mkdir `build` && cd `build`
+- cmake `[path to this source dir]`-DCMAKE_INSTALL_PREFIX=`path to install dir`
+- make && make install
+- texhash `path to install dir`
+
+To match the `make` based installation, `texhash` must be invoked manually, but it allows for greater flexibility on the
+selection of the target directory.
 
 
 [eushield.sty]: http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The document class requires the following packages:
 where *eushield* is the only nonstandard LaTeX package. The package provides various versions of the university's crest. The [eushield][eushield.sty] package is not distributed along with this class. 
 
 You can obtain a copy of it via [Informatics DReaM](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty). You must also obtain the following necessary copies of the university crest:
+* eushield-normal.[[eps](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.eps)]
 * eushield-normal.[[pdf](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-normal.pdf)][[ps](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-normal.ps)]
 * eushield-noback.[[pdf](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-noback.pdf)][[ps](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-noback.ps)]
 * eushield-reversed.[[pdf](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-reversed.pdf)][[ps](http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield-reversed.ps)]
@@ -36,17 +37,18 @@ and will also invoke `texhash` in order to update the search paths.
 
 ## Using `cmake`
 
-- mkdir `build` && cd `build`
-- cmake `[path to this source dir]`-DCMAKE_INSTALL_PREFIX=`path to install dir`
-- make && make install
-- texhash `path to install dir`
+- `mkdir build && cd build`
+- `cmake [path to this source dir] -DCMAKE_INSTALL_PREFIX=[path to install dir]`
+- `make && make install`
+- `texhash [path to install dir]`
 
 To match the `make` based installation, `texhash` must be invoked manually, but it allows for greater flexibility on the
 selection of the target directory.
 
 Moreover, the `cmake` file `uoe-infthesis-latex-cls.cmake` allows the integration of this repository as a submodule, 
 allowing the creation of targets with the relevant files as shown in this project's `CMakeLists.txt` file. The handling
-of the paths for LaTeX will still need to be handled separately.
+of the paths for LaTeX will still need to be handled separately. For an example have a look
+[here](https://github.com/compor/uoe-inf-thesis-skeleton).
 
 
 [eushield.sty]: http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ You can obtain a copy of it via [Informatics DReaM](http://dream.inf.ed.ac.uk/pr
 **Note** all usage of the university's crest or logos is subject to the [brand guidelines](http://www.ed.ac.uk/communications-marketing/resources/university-brand). Make sure you follow the brand guidelines!
 
 ## Local installation
-To be written...
+
+To install the thesis class file:
+
+`make install`
+
+To install the crest and logos:
+
+`make install-eushield`
+
+Both above commands will place all the relevant files under a `.texmf` directory in the current user's `HOME` directory
+and will also invoke `texhash` in order to update the search paths.
+
 
 [eushield.sty]: http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,12 @@
 # cmake file
 
-set(UOE_DIR "uoe/informatics/")
+set(UOE_DIR "uoe")
+set(INF_DIR "${UOE_DIR}/informatics")
 
 
 # setup logos
 
-set(EUSHIELD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${UOE_DIR}/eushield")
+set(EUSHIELD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${INF_DIR}/eushield")
 file(MAKE_DIRECTORY ${EUSHIELD_DIR})
 
 set(EUSHIELD_URL
@@ -45,7 +46,7 @@ add_custom_target(uoe-eushield ALL
 set(INFTHESIS_FILE "infthesis.cls")
 set(INFTHESIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INFTHESIS_FILE}")
 
-set(INFTHESIS_DIR "${UOE_DIR}/infthesis")
+set(INFTHESIS_DIR "${INF_DIR}/infthesis")
 set(INFTHESIS_DEST_PATH "${INFTHESIS_DIR}/${INFTHESIS_FILE}")
 file(MAKE_DIRECTORY ${INFTHESIS_DIR})
 
@@ -59,4 +60,9 @@ add_custom_command(
 
 add_custom_target(uoe-infthesis ALL
   DEPENDS ${INFTHESIS_DEST_PATH})
+
+
+# installation
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${UOE_DIR} DESTINATION .)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 # cmake file
 
-#
-
 set(UOE_DIR "uoe/informatics/")
 
 
@@ -26,9 +24,20 @@ list(APPEND EUSHIELD_LOGOS eushield-twocolour.ps)
 list(APPEND EUSHIELD_LOGOS eushield-fullcolour.pdf)
 list(APPEND EUSHIELD_LOGOS eushield-fullcolour.ps)
 
+set(DOWNLOAD_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/download.cmake")
+set(EUSHIELD_DEST_LOGOS)
 foreach(logo ${EUSHIELD_LOGOS})
-  file(DOWNLOAD ${EUSHIELD_URL}/${logo} ${EUSHIELD_DIR}/${logo})
+  file(APPEND ${DOWNLOAD_SCRIPT} 
+    "file(DOWNLOAD ${EUSHIELD_URL}/${logo} ${EUSHIELD_DIR}/${logo})\n")
+  list(APPEND EUSHIELD_DEST_LOGOS ${EUSHIELD_DIR}/${logo})
 endforeach()
+
+add_custom_command(
+  OUTPUT ${EUSHIELD_DEST_LOGOS}
+  COMMAND ${CMAKE_COMMAND} -P ${DOWNLOAD_SCRIPT})
+
+add_custom_target(uoe-eushield ALL
+  DEPENDS ${EUSHIELD_DEST_LOGOS})
 
 
 # setup latex class file
@@ -43,7 +52,8 @@ file(MAKE_DIRECTORY ${INFTHESIS_DIR})
 file(TO_NATIVE_PATH ${INFTHESIS_PATH} INFTHESIS_NPATH)
 file(TO_NATIVE_PATH ${INFTHESIS_DEST_PATH} INFTHESIS_DEST_NPATH)
 
-add_custom_command(OUTPUT ${INFTHESIS_DEST_PATH}
+add_custom_command(
+  OUTPUT ${INFTHESIS_DEST_PATH}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${INFTHESIS_NPATH} ${INFTHESIS_DEST_NPATH})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,68 +1,18 @@
 # cmake file
 
-set(UOE_DIR "uoe")
-set(INF_DIR "${UOE_DIR}/informatics")
-
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
+include(uoe-infthesis-latex-cls)
 
 # setup logos
 
-set(EUSHIELD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${INF_DIR}/eushield")
-file(MAKE_DIRECTORY ${EUSHIELD_DIR})
-
-set(EUSHIELD_URL
-  http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos)
-
-set(EUSHIELD_LOGOS)
-list(APPEND EUSHIELD_LOGOS eushield.sty)
-list(APPEND EUSHIELD_LOGOS eushield-normal.pdf)
-list(APPEND EUSHIELD_LOGOS eushield-normal.ps)
-list(APPEND EUSHIELD_LOGOS eushield-noback.pdf)
-list(APPEND EUSHIELD_LOGOS eushield-noback.ps)
-list(APPEND EUSHIELD_LOGOS eushield-reversed.pdf)
-list(APPEND EUSHIELD_LOGOS eushield-reversed.ps)
-list(APPEND EUSHIELD_LOGOS eushield-twocolour.pdf)
-list(APPEND EUSHIELD_LOGOS eushield-twocolour.ps)
-list(APPEND EUSHIELD_LOGOS eushield-fullcolour.pdf)
-list(APPEND EUSHIELD_LOGOS eushield-fullcolour.ps)
-
-set(DOWNLOAD_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/download.cmake")
-set(EUSHIELD_DEST_LOGOS)
-foreach(logo ${EUSHIELD_LOGOS})
-  file(APPEND ${DOWNLOAD_SCRIPT} 
-    "file(DOWNLOAD ${EUSHIELD_URL}/${logo} ${EUSHIELD_DIR}/${logo})\n")
-  list(APPEND EUSHIELD_DEST_LOGOS ${EUSHIELD_DIR}/${logo})
-endforeach()
-
-add_custom_command(
-  OUTPUT ${EUSHIELD_DEST_LOGOS}
-  COMMAND ${CMAKE_COMMAND} -P ${DOWNLOAD_SCRIPT})
-
-add_custom_target(uoe-eushield ALL
-  DEPENDS ${EUSHIELD_DEST_LOGOS})
-
+add_uoe_eushield(TARGET my-eushield)
 
 # setup latex class file
 
-set(INFTHESIS_FILE "infthesis.cls")
-set(INFTHESIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INFTHESIS_FILE}")
-
-set(INFTHESIS_DIR "${INF_DIR}/infthesis")
-set(INFTHESIS_DEST_PATH "${INFTHESIS_DIR}/${INFTHESIS_FILE}")
-file(MAKE_DIRECTORY ${INFTHESIS_DIR})
-
-file(TO_NATIVE_PATH ${INFTHESIS_PATH} INFTHESIS_NPATH)
-file(TO_NATIVE_PATH ${INFTHESIS_DEST_PATH} INFTHESIS_DEST_NPATH)
-
-add_custom_command(
-  OUTPUT ${INFTHESIS_DEST_PATH}
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${INFTHESIS_NPATH} ${INFTHESIS_DEST_NPATH})
-
-add_custom_target(uoe-infthesis ALL
-  DEPENDS ${INFTHESIS_DEST_PATH})
-
+add_uoe_infthesis(TARGET my-infthesis)
 
 # installation
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${UOE_DIR} DESTINATION .)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-eushield/uoe DESTINATION .)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-infthesis/uoe DESTINATION .)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,52 @@
+# cmake file
+
+#
+
+set(UOE_DIR "uoe/informatics/")
+
+
+# setup logos
+
+set(EUSHIELD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${UOE_DIR}/eushield")
+file(MAKE_DIRECTORY ${EUSHIELD_DIR})
+
+set(EUSHIELD_URL
+  http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos)
+
+set(EUSHIELD_LOGOS)
+list(APPEND EUSHIELD_LOGOS eushield.sty)
+list(APPEND EUSHIELD_LOGOS eushield-normal.pdf)
+list(APPEND EUSHIELD_LOGOS eushield-normal.ps)
+list(APPEND EUSHIELD_LOGOS eushield-noback.pdf)
+list(APPEND EUSHIELD_LOGOS eushield-noback.ps)
+list(APPEND EUSHIELD_LOGOS eushield-reversed.pdf)
+list(APPEND EUSHIELD_LOGOS eushield-reversed.ps)
+list(APPEND EUSHIELD_LOGOS eushield-twocolour.pdf)
+list(APPEND EUSHIELD_LOGOS eushield-twocolour.ps)
+list(APPEND EUSHIELD_LOGOS eushield-fullcolour.pdf)
+list(APPEND EUSHIELD_LOGOS eushield-fullcolour.ps)
+
+foreach(logo ${EUSHIELD_LOGOS})
+  file(DOWNLOAD ${EUSHIELD_URL}/${logo} ${EUSHIELD_DIR}/${logo})
+endforeach()
+
+
+# setup latex class file
+
+set(INFTHESIS_FILE "infthesis.cls")
+set(INFTHESIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INFTHESIS_FILE}")
+
+set(INFTHESIS_DIR "${UOE_DIR}/infthesis")
+set(INFTHESIS_DEST_PATH "${INFTHESIS_DIR}/${INFTHESIS_FILE}")
+file(MAKE_DIRECTORY ${INFTHESIS_DIR})
+
+file(TO_NATIVE_PATH ${INFTHESIS_PATH} INFTHESIS_NPATH)
+file(TO_NATIVE_PATH ${INFTHESIS_DEST_PATH} INFTHESIS_DEST_NPATH)
+
+add_custom_command(OUTPUT ${INFTHESIS_DEST_PATH}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  ${INFTHESIS_NPATH} ${INFTHESIS_DEST_NPATH})
+
+add_custom_target(uoe-infthesis ALL
+  DEPENDS ${INFTHESIS_DEST_PATH})
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 TEXMF=$(HOME)/.texmf/tex/latex
-TEXINFTHESIS=$(TEXMF)/informatics/infthesis
-TEXEUSHIELD=$(TEXMF)/informatics/eushield
+TEXINFTHESIS=$(TEXMF)/uoe/informatics/infthesis
+TEXEUSHIELD=$(TEXMF)/uoe/informatics/eushield
 EUSHIELDURL=http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos
 EUSHIELD= \
 	eushield.sty \

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ TEXINFTHESIS=$(TEXMF)/uoe/informatics/infthesis
 TEXEUSHIELD=$(TEXMF)/uoe/informatics/eushield
 EUSHIELDURL=http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos
 EUSHIELD= \
-	eushield.sty \
+	eushield.sty eushield.eps \
 	eushield-normal.pdf eushield-normal.ps \
 	eushield-noback.pdf eushield-noback.ps \
 	eushield-reversed.pdf eushield-reversed.ps \

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -1,0 +1,112 @@
+# cmake file
+
+include(CMakeParseArguments)
+
+#.rst:
+# This creates targets that install the LaTeX class for an University of
+# Edinburgh, School of Informatics thesis class (infthesis) along with the
+# relevant crest logos.
+#
+# Usage:
+#
+#     include(uoe-infthesis-latex-cls)
+#
+#     add_uoe_thesis(TARGET my-thesis-class)
+#     add_uoe_eushield(TARGET my-eushield)
+#
+# Each command creates a directory with the targets name, under which a
+# directory named "uoe" is placed with all the relevant files per target. This
+# subdirectory can by used to install these files to the desired location using
+# an install() command.
+#
+
+function(add_uoe_eushield)
+  set(options)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs)
+
+  cmake_parse_arguments(ADD_UOE_EUSHIELD
+    "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  if ("${ADD_UOE_EUSHIELD_TARGET}" STREQUAL "")
+    message(FATAL_ERROR
+      "add_uoe_eushield() requires a target name by using the TARGET option")
+  endif()
+
+  set(UOE_DIR "${ADD_UOE_EUSHIELD_TARGET}/uoe")
+  set(INF_DIR "${UOE_DIR}/informatics")
+
+  # setup logos
+
+  set(EUSHIELD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${INF_DIR}/eushield")
+  file(MAKE_DIRECTORY ${EUSHIELD_DIR})
+
+  set(EUSHIELD_URL
+    http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos)
+
+  set(EUSHIELD_LOGOS)
+  list(APPEND EUSHIELD_LOGOS eushield.sty)
+  list(APPEND EUSHIELD_LOGOS eushield-normal.pdf)
+  list(APPEND EUSHIELD_LOGOS eushield-normal.ps)
+  list(APPEND EUSHIELD_LOGOS eushield-noback.pdf)
+  list(APPEND EUSHIELD_LOGOS eushield-noback.ps)
+  list(APPEND EUSHIELD_LOGOS eushield-reversed.pdf)
+  list(APPEND EUSHIELD_LOGOS eushield-reversed.ps)
+  list(APPEND EUSHIELD_LOGOS eushield-twocolour.pdf)
+  list(APPEND EUSHIELD_LOGOS eushield-twocolour.ps)
+  list(APPEND EUSHIELD_LOGOS eushield-fullcolour.pdf)
+  list(APPEND EUSHIELD_LOGOS eushield-fullcolour.ps)
+
+  set(DOWNLOAD_SCRIPT
+    "${CMAKE_CURRENT_BINARY_DIR}/${ADD_UOE_EUSHIELD_TARGET}-download.cmake")
+  set(EUSHIELD_DEST_LOGOS)
+  foreach(logo ${EUSHIELD_LOGOS})
+    file(APPEND ${DOWNLOAD_SCRIPT}
+      "file(DOWNLOAD ${EUSHIELD_URL}/${logo} ${EUSHIELD_DIR}/${logo})\n")
+    list(APPEND EUSHIELD_DEST_LOGOS ${EUSHIELD_DIR}/${logo})
+  endforeach()
+
+  add_custom_command(
+    OUTPUT ${EUSHIELD_DEST_LOGOS}
+    COMMAND ${CMAKE_COMMAND} -P ${DOWNLOAD_SCRIPT})
+
+  add_custom_target(${ADD_UOE_EUSHIELD_TARGET} ALL
+    DEPENDS ${EUSHIELD_DEST_LOGOS})
+endfunction()
+
+
+function(add_uoe_infthesis)
+  set(options)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs)
+
+  cmake_parse_arguments(ADD_UOE_INFTHESIS
+    "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  if ("${ADD_UOE_INFTHESIS_TARGET}" STREQUAL "")
+    message(FATAL_ERROR
+      "add_uoe_infthesis() requires a target name by using the TARGET option")
+  endif()
+
+  set(UOE_DIR "${ADD_UOE_INFTHESIS_TARGET}/uoe")
+  set(INF_DIR "${UOE_DIR}/informatics")
+
+  set(INFTHESIS_FILE "infthesis.cls")
+  set(INFTHESIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INFTHESIS_FILE}")
+
+  set(INFTHESIS_DIR "${INF_DIR}/infthesis")
+  set(INFTHESIS_DEST_PATH "${INFTHESIS_DIR}/${INFTHESIS_FILE}")
+  file(MAKE_DIRECTORY ${INFTHESIS_DIR})
+
+  file(TO_NATIVE_PATH ${INFTHESIS_PATH} INFTHESIS_NPATH)
+  file(TO_NATIVE_PATH ${INFTHESIS_DEST_PATH} INFTHESIS_DEST_NPATH)
+
+  add_custom_command(
+    OUTPUT ${INFTHESIS_DEST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${INFTHESIS_NPATH} ${INFTHESIS_DEST_NPATH})
+
+  add_custom_target(${ADD_UOE_INFTHESIS_TARGET} ALL
+    DEPENDS ${INFTHESIS_DEST_PATH})
+endfunction()
+

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -2,6 +2,8 @@
 
 include(CMakeParseArguments)
 
+set(_UOE_INFTHESIS_CURRENT_DIR "${CMAKE_CURRENT_LIST_DIR}/src")
+
 #.rst:
 # This creates targets that install the LaTeX class for an University of
 # Edinburgh, School of Informatics thesis class (infthesis) along with the
@@ -92,7 +94,7 @@ function(add_uoe_infthesis)
   set(INF_DIR "${UOE_DIR}/informatics")
 
   set(INFTHESIS_FILE "infthesis.cls")
-  set(INFTHESIS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${INFTHESIS_FILE}")
+  set(INFTHESIS_PATH "${_UOE_INFTHESIS_CURRENT_DIR}/${INFTHESIS_FILE}")
 
   set(INFTHESIS_DIR "${INF_DIR}/infthesis")
   set(INFTHESIS_DEST_PATH "${INFTHESIS_DIR}/${INFTHESIS_FILE}")

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -48,6 +48,7 @@ function(add_uoe_eushield)
 
   set(EUSHIELD_LOGOS)
   list(APPEND EUSHIELD_LOGOS eushield.sty)
+  list(APPEND EUSHIELD_LOGOS eushield.eps)
   list(APPEND EUSHIELD_LOGOS eushield-normal.pdf)
   list(APPEND EUSHIELD_LOGOS eushield-normal.ps)
   list(APPEND EUSHIELD_LOGOS eushield-noback.pdf)

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -35,7 +35,7 @@ function(add_uoe_eushield)
       "add_uoe_eushield() requires a target name by using the TARGET option")
   endif()
 
-  set(UOE_DIR "${ADD_UOE_EUSHIELD_TARGET}/uoe")
+  set(UOE_DIR "${ADD_UOE_EUSHIELD_TARGET}/tex/latex/uoe")
   set(INF_DIR "${UOE_DIR}/informatics")
 
   # setup logos
@@ -90,7 +90,7 @@ function(add_uoe_infthesis)
       "add_uoe_infthesis() requires a target name by using the TARGET option")
   endif()
 
-  set(UOE_DIR "${ADD_UOE_INFTHESIS_TARGET}/uoe")
+  set(UOE_DIR "${ADD_UOE_INFTHESIS_TARGET}/tex/latex/uoe")
   set(INF_DIR "${UOE_DIR}/informatics")
 
   set(INFTHESIS_FILE "infthesis.cls")


### PR DESCRIPTION
- add `cmake` configuration equivalent to the one provided by the current `Makefile` (minor path changes)
- add `cmake` configuration file that allows to use this project as a `git` sub-module to avoid redundant (and possibly out-of-date) copies
- update readme to reflect above changes
- add missing crest graphic download, required for the default usage of the `logo` option of `infthesis` document class
