### PR TITLE
Extra logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # LaTeX class for Informatics theses
-This LaTeX class provide a document class for typesetting Informatics dissertations. It is a fork of `infthesis.cls` as found on Informatics DICE machines, however I have patched the class in various ways to make it more flexible.
+This LaTeX class provides a document class for typesetting Informatics dissertations. 
+
+It is a fork of `infthesis.cls` as found on Informatics DICE machines, however I have patched the class in various ways to make it more flexible. 
+For the original class file and a basic usage example, look [here](http://www.inf.ed.ac.uk/systems/tex/informatics/infthesis).
 
 ## Dependencies
 The document class requires the following packages:
@@ -22,11 +25,17 @@ You can obtain a copy of it via [Informatics DReaM](http://dream.inf.ed.ac.uk/pr
 
 ## Other useful logos
 
-https://www.epsrc.ac.uk/about/logos/
-http://web.inf.ed.ac.uk/infweb/admin/school-brand
-http://web.inf.ed.ac.uk/infweb/student-services/cdt/ppar/resources-guidelines/ppar-logos 
+Other commonly useful logos:
+
+* [UoE Informatics logos](http://web.inf.ed.ac.uk/infweb/admin/school-brand)
+* [UoE CDT PPar logos](http://web.inf.ed.ac.uk/infweb/student-services/cdt/ppar/resources-guidelines/ppar-logos)
+* [EPSRC logos](https://www.epsrc.ac.uk/about/logos)
+
+Make sure to follow the brand guidelines as stated in each site!
 
 ## Local installation
+
+## LaTeX class and main crest
 
 ## Using `make`
 
@@ -40,6 +49,15 @@ To install the crest and logos (in the `src` dir):
 
 Both above commands will place all the relevant files under a `.texmf` directory in the current user's `HOME` directory
 and will also invoke `texhash` in order to update the search paths.
+
+For the extra logos, 3 targets are declared and can be used as follows:
+
+- `make install-logo-inf`
+- `make install-logo-cdtppar`
+- `make install-logo-epsrc`
+
+Each target creates a corresponding subdirectory under `logos/` with all the relevant logos (in vector format). The
+installation directory can be influence using the `DESTDIR` variable as stated [here](https://www.gnu.org/prep/standards/html_node/DESTDIR.html).
 
 ## Using `cmake`
 
@@ -56,5 +74,17 @@ allowing the creation of targets with the relevant files as shown in this projec
 method requires that the handling of the paths for LaTeX will have to be performed separately. For an example have a
 look [here](https://github.com/compor/uoe-inf-thesis-skeleton).
 
+The commands defined are:
+
+- `add_uoe_eushield`
+- `add_uoe_infthesis`
+
+For the extra logos, the submodule `uoe-logos-extra.cmake` has to be included in your project. The commands defined are:
+
+- `add_uoe_inf_logos`
+- `add_uoe_cdtppar_logos`
+- `add_uoe_epsrc_logos`
+
 
 [eushield.sty]: http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos/eushield.sty
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ You can obtain a copy of it via [Informatics DReaM](http://dream.inf.ed.ac.uk/pr
 
 **Note** all usage of the university's crest or logos is subject to the [brand guidelines](http://www.ed.ac.uk/communications-marketing/resources/university-brand). Make sure you follow the brand guidelines!
 
+## Other useful logos
+
+https://www.epsrc.ac.uk/about/logos/
+http://web.inf.ed.ac.uk/infweb/admin/school-brand
+http://web.inf.ed.ac.uk/infweb/student-services/cdt/ppar/resources-guidelines/ppar-logos 
+
 ## Local installation
 
 ## Using `make`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 # cmake file
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
+
+
+# basic LaTeX class download
+
 include(uoe-infthesis-latex-cls)
 
 # setup logos
@@ -15,4 +19,19 @@ add_uoe_infthesis(TARGET my-infthesis)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-eushield/ DESTINATION .)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-infthesis/ DESTINATION .)
+
+
+# extra logos download
+
+include(uoe-logos-extra)
+
+add_uoe_inf_logos(TARGET my-inf-logos)
+add_uoe_cdtppar_logos(TARGET my-ppar-logos)
+add_uoe_epsrc_logos(TARGET my-epsrc-logos)
+
+# installation
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-inf-logos/ DESTINATION .)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-ppar-logos/ DESTINATION .)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/my-epsrc-logos/ DESTINATION .)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,10 @@
+#
+
+DESTDIR?=.
+
 TEXMF=$(HOME)/.texmf/tex/latex
 TEXINFTHESIS=$(TEXMF)/uoe/informatics/infthesis
+
 TEXEUSHIELD=$(TEXMF)/uoe/informatics/eushield
 EUSHIELDURL=http://dream.inf.ed.ac.uk/projects/polyml/application/cover-letter/tex/logos
 EUSHIELD= \
@@ -9,6 +14,21 @@ EUSHIELD= \
 	eushield-reversed.pdf eushield-reversed.ps \
 	eushield-twocolour.pdf eushield-twocolour.ps \
 	eushield-fullcolour.pdf eushield-fullcolour.ps
+
+INFLOGODIR=$(DESTDIR)/logos/informatics
+INFURL=http://media.inf.ed.ac.uk/infweb/logos
+INFLOGO=InformaticsUni_spot.eps InformaticsUni_CMYK.eps
+
+CDTPPARLOGODIR=$(DESTDIR)/logos/cdtppar
+CDTPPARURL=http://media.inf.ed.ac.uk/infweb/ppar-logos
+CDTPPARLOGO=cmyk.eps black.eps white.eps
+
+EPSRCLOGODIR=$(DESTDIR)/logos/epsrc
+EPSRCURL=https://www.epsrc.ac.uk/files/aboutus/logos-and-indentity
+EPSRCLOGO=white-out-sponsorship-logo:sponsor-wofullres.eps \
+					black-and-white-sponsorship-logo-full-resolution:sponsor-bwfullres.eps \
+					colour-sponsorship-logo-full-resolution:sponsorfullres.eps
+
 
 install: infthesis.cls
 	@mkdir -v -p $(TEXINFTHESIS) && \
@@ -24,3 +44,30 @@ install-eushield: infthesis.cls
 		echo "Installation of $(dep) complete." || echo "Installation of $(dep) failed." ; \
 	)
 	texhash $(TEXMF)
+
+install-logo-inf:
+	@mkdir -v -p $(INFLOGODIR)
+	$(foreach dep, $(INFLOGO), \
+		echo "Installing $(dep)..." && \
+		curl -o $(INFLOGODIR)/$(dep) -O $(INFURL)/$(dep) && \
+		echo "Installation of $(dep) complete." || echo "Installation of $(dep) failed." ; \
+	)
+
+install-logo-cdtppar:
+	@mkdir -v -p $(CDTPPARLOGODIR)
+	$(foreach dep, $(CDTPPARLOGO), \
+		echo "Installing $(dep)..." && \
+		curl -o $(CDTPPARLOGODIR)/$(dep) -O $(CDTPPARURL)/$(dep) && \
+		echo "Installation of $(dep) complete." || echo "Installation of $(dep) failed." ; \
+	)
+
+install-logo-epsrc:
+	@mkdir -v -p $(EPSRCLOGODIR)
+	$(foreach dep, $(EPSRCLOGO), \
+		$(eval dep1 = $(word 1,$(subst :, ,$(dep)))) \
+		$(eval dep2 = $(word 2,$(subst :, ,$(dep)))) \
+		echo "Installing $(dep2)..." && \
+		curl -o $(EPSRCLOGODIR)/$(dep2) -O $(EPSRCURL)/$(dep1) && \
+		echo "Installation of $(dep2) complete." || echo "Installation of $(dep2) failed." ; \
+	)
+

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -5,9 +5,9 @@ include(CMakeParseArguments)
 set(_UOE_INFTHESIS_CURRENT_DIR "${CMAKE_CURRENT_LIST_DIR}/src")
 
 #.rst:
-# This creates targets that install the LaTeX class for an University of
-# Edinburgh, School of Informatics thesis class (infthesis) along with the
-# relevant crest logos.
+# This module defines commands that allow the installation of the LaTeX class
+# for a University of Edinburgh, School of Informatics thesis class (infthesis)
+# along with the relevant crest logos.
 #
 # Usage:
 #
@@ -17,8 +17,8 @@ set(_UOE_INFTHESIS_CURRENT_DIR "${CMAKE_CURRENT_LIST_DIR}/src")
 #     add_uoe_eushield(TARGET my-eushield)
 #
 # Each command creates a directory with the targets name, under which a
-# directory named "uoe" is placed with all the relevant files per target. This
-# subdirectory can by used to install these files to the desired location using
+# directory named "uoe" is placed with all the relevant files per target. These
+# directories can by used to install these files to the desired location using
 # an install() command.
 #
 

--- a/uoe-infthesis-latex-cls.cmake
+++ b/uoe-infthesis-latex-cls.cmake
@@ -62,6 +62,8 @@ function(add_uoe_eushield)
 
   set(DOWNLOAD_SCRIPT
     "${CMAKE_CURRENT_BINARY_DIR}/${ADD_UOE_EUSHIELD_TARGET}-download.cmake")
+  file(REMOVE ${DOWNLOAD_SCRIPT})
+
   set(EUSHIELD_DEST_LOGOS)
   foreach(logo ${EUSHIELD_LOGOS})
     file(APPEND ${DOWNLOAD_SCRIPT}

--- a/uoe-logos-extra.cmake
+++ b/uoe-logos-extra.cmake
@@ -1,0 +1,115 @@
+# cmake file
+
+include(CMakeParseArguments)
+
+#.rst:
+# This module defines commands that download and install common logos (in vector
+# format) usually required by students of the School of Informatics, University
+# of Edinburgh, for typesetting various documents.
+#
+# Usage:
+#
+#     include(uoe-logos-extra)
+#
+#     add_uoe_inf_logos(TARGET my-inf-logos)
+#     add_uoe_cdtppar_logos(TARGET my-ppar-logos)
+#     add_uoe_esprc_logos(TARGET my-epsrc-logos)
+#
+# Each command creates a directory with the targets name, under which all the
+# relevant files per target are placed. This directory can by used to install
+# these files to the desired location using an install() command.
+#
+
+# internal function
+function(_add_uoe_files)
+  set(options)
+  set(oneValueArgs SELF TARGET URL)
+  set(multiValueArgs REMOTE_FILES LOCAL_FILES)
+
+  cmake_parse_arguments(ADD_UOE_FILES
+    "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(NOT ADD_UOE_FILES_SELF)
+    message(FATAL_ERROR "requires SELF option")
+  endif()
+  set(SELF ${ADD_UOE_FILES_SELF})
+
+  if(NOT ADD_UOE_FILES_TARGET)
+    message(FATAL_ERROR "${SELF}() requires a TARGET option")
+  endif()
+
+  if(NOT ADD_UOE_FILES_URL)
+    message(FATAL_ERROR "${SELF}() requires a URL option")
+  endif()
+
+  if(NOT ADD_UOE_FILES_REMOTE_FILES)
+    message(FATAL_ERROR "${SELF}() requires a REMOTE_FILES option")
+  endif()
+
+  list(LENGTH ADD_UOE_FILES_REMOTE_FILES remote_files_len)
+  list(LENGTH ADD_UOE_FILES_LOCAL_FILES local_files_len)
+
+  if(${local_files_len} GREATER ${remote_files_len})
+    message(FATAL_ERROR "${SELF}() has extraneous LOCAL_FILES declared")
+  endif()
+
+  if(ADD_UOE_FILES_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "${SELF}() has extraneous arguments declared")
+  endif()
+
+  # setup files
+  set(DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}/${ADD_UOE_FILES_TARGET}")
+  file(MAKE_DIRECTORY ${DEST_DIR})
+  set(DOWNLOAD_SCRIPT
+    "${CMAKE_CURRENT_BINARY_DIR}/${ADD_UOE_FILES_TARGET}-download.cmake")
+  file(REMOVE ${DOWNLOAD_SCRIPT})
+
+  set(DEST_FILES)
+  math(EXPR len "${remote_files_len}-1")
+  foreach(idx RANGE ${len})
+    list(GET ADD_UOE_FILES_REMOTE_FILES ${idx} remote_file)
+    list(GET ADD_UOE_FILES_LOCAL_FILES ${idx} local_file)
+
+    if(NOT local_file)
+      set(local_file ${remote_file})
+    endif()
+
+    file(APPEND ${DOWNLOAD_SCRIPT}
+      "file(DOWNLOAD ${ADD_UOE_FILES_URL}/${remote_file} ${DEST_DIR}/${local_file})\n")
+    list(APPEND DEST_FILES ${DEST_DIR}/${local_file})
+  endforeach()
+
+  add_custom_command(OUTPUT ${DEST_FILES}
+    COMMAND ${CMAKE_COMMAND} -P ${DOWNLOAD_SCRIPT})
+
+  add_custom_target(${ADD_UOE_FILES_TARGET} ALL DEPENDS ${DEST_FILES})
+endfunction()
+
+function(add_uoe_inf_logos)
+  _add_uoe_files(SELF "add_uoe_inf_logos"
+    URL http://media.inf.ed.ac.uk/infweb/logos
+    REMOTE_FILES InformaticsUni_spot.eps InformaticsUni_CMYK.eps
+    ${ARGN})
+endfunction()
+
+function(add_uoe_cdtppar_logos)
+  _add_uoe_files(SELF "add_uoe_cdtppar_logos"
+    URL "http://media.inf.ed.ac.uk/infweb/ppar-logos"
+    REMOTE_FILES cmyk.eps black.eps white.eps
+    ${ARGN})
+endfunction()
+
+function(add_uoe_epsrc_logos)
+  _add_uoe_files(SELF "add_uoe_epsrc_logos"
+    URL https://www.epsrc.ac.uk/files/aboutus/logos-and-indentity
+    REMOTE_FILES
+    white-out-sponsorship-logo
+    black-and-white-sponsorship-logo-full-resolution
+    colour-sponsorship-logo-full-resolution
+    LOCAL_FILES
+    sponsor-wofullres.eps
+    sponsor-bwfullres.eps
+    sponsorfullres.eps
+    ${ARGN})
+endfunction()
+


### PR DESCRIPTION
- Added targets on both `make` and `cmake` files for extra logos (EPSRC, UoE Informatics, CDT PPar)
  This avoids the use of the disclaimer since it follows the current method of just downloading the logos.
- Updated documentation with usage and URL links.
- Minor bug fix on the `cmake` download script.